### PR TITLE
Add timestamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supports attachments but can only output emails with the HTML and plain text con
 
 ### Legacy Command line:
 ```
-usage: olmConvert.py [-h] [--noAttachments] [--format {eml,html}] [--verbose] olmPath outputDir
+usage: olmConvert.py [-h] [--noAttachments] [--timestamps] [--format {eml,html}] [--verbose] olmPath outputDir
 
 positional arguments:
   olmPath              Path to OLM file
@@ -37,6 +37,7 @@ positional arguments:
 options:
   -h, --help           show this help message and exit
   --noAttachments      Don't include attachments in output (decreasing file size)
+  --timestamps         Adjust each file's timestamp to corresponding send time
   --format {eml,html}  Specifies output format
   --verbose            Verbose output
 ```

--- a/olmConvert.py
+++ b/olmConvert.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from dateutil import parser
 import base64
 import warnings
 import html
@@ -23,6 +24,9 @@ def main():
     parser.add_argument('--noAttachments', action='store_true', default=False,
                     help='Don\'t include attachments in output (decreasing file size)')
 
+    parser.add_argument('--timestamps', action='store_true', default=False,
+                    help='Set timestamp of each file to sent date')
+
     parser.add_argument('--format', choices=['eml', 'html'], default="eml",
                     help='Specifies output format')
 
@@ -32,11 +36,11 @@ def main():
     args = parser.parse_args()
 
     print(f"Beginning conversion of {args.olmPath.name}....")
-    convertOLM(args.olmPath, args.outputDir, noAttachments=args.noAttachments, format=args.format, verbose=args.verbose)
+    convertOLM(args.olmPath, args.outputDir, noAttachments=args.noAttachments, timestamps=args.timestamps, format=args.format, verbose=args.verbose)
     print(f"Conversion complete! Files have been written to directory at {args.outputDir}.")
 
 # Convert OLM file specified by olmPath, creating a directory of EML files at outputDir
-def convertOLM(olmPath, outputDir, noAttachments=False, verbose=False, format="eml"):
+def convertOLM(olmPath, outputDir, noAttachments=False, timestamps=False, verbose=False, format="eml"):
     if format not in ["eml", "html"]:
         raise ValueError(f"Unknown format '{format}', Valid formats are 'eml', 'html'.")
 
@@ -89,6 +93,9 @@ def convertOLM(olmPath, outputDir, noAttachments=False, verbose=False, format="e
                 outputFile = open(newPath, "w", encoding='utf-8')
                 outputFile.write(messageEmlStr)
                 outputFile.close()
+                if (timestamps):
+                    ts = parser.parse(messageEml.date).timestamp()
+                    os.utime(newPath, times=(ts,ts))
                 if (verbose):
                     sys.stdout.write(f"[{messageIndex}/{messageListLen}]: Written {newPath}\n")
             except Exception as e:

--- a/olmConvertGUI.py
+++ b/olmConvertGUI.py
@@ -72,21 +72,27 @@ attachments_var = tk.BooleanVar(value = True)
 attachments_checkbox = ttk.Checkbutton(frame, text="Include attachments", variable=attachments_var)
 attachments_checkbox.grid(column=1, row=5, sticky="E", padx=5)
 
+# Timestamps checkbox
+
+timestamps_var = tk.BooleanVar(value = True)
+timestamps_checkbox = ttk.Checkbutton(frame, text="Timestamp files", variable=timestamps_var)
+timestamps_checkbox.grid(column=1, row=6, sticky="E", padx=5)
+
 # Output format radio
 
-ttk.Label(frame, text="Output file format:").grid(column=0, row=6, sticky="E")
+ttk.Label(frame, text="Output file format:").grid(column=0, row=7, sticky="E")
 format_var = tk.StringVar(value = "eml")
 eml_radio = ttk.Radiobutton(frame, text="EML", variable=format_var, value="eml")
-eml_radio.grid(column=1, row=6, sticky="W", padx=5)
+eml_radio.grid(column=1, row=7, sticky="W", padx=5)
 html_radio = ttk.Radiobutton(frame, text="HTML", variable=format_var, value="html")
-html_radio.grid(column=1, row=7, sticky="W", padx=5)
+html_radio.grid(column=1, row=8, sticky="W", padx=5)
 
 # Convert button
 
 def run_convert():
     def convert_wrapper():
         try:
-            olmConvert.convertOLM(olm_path_entry.get(), output_path_entry.get(), not attachments_var.get(), True, format=format_var.get())
+            olmConvert.convertOLM(olm_path_entry.get(), output_path_entry.get(), not attachments_var.get(), timestamps_var.get(), verbose=True, format=format_var.get())
             messagebox.showinfo("Conversion complete", "The conversion has finished successfully.")
             try:
                 if platform.system() == "Darwin":
@@ -115,13 +121,13 @@ def run_convert():
         convert_thread.start()
 
 convert_btn = ttk.Button(frame, text="Convert!", command=run_convert)
-convert_btn.grid(column=2, row=7)
+convert_btn.grid(column=2, row=8)
 
 # Progress bar
 
 progress = tk.DoubleVar()
 progressbar = ttk.Progressbar(frame, variable=progress, length=500)
-progressbar.grid(column=0, row=8, columnspan=3)
+progressbar.grid(column=0, row=9, columnspan=3)
 
 # Output entry
 
@@ -131,14 +137,14 @@ def toggle_output():
     if (not output_shown_flag.get()):
         output_shown_flag.set(True)
         output_label.config(text="▼ Output (advanced):")
-        output_text.grid(column=0, row=10, columnspan=3)
+        output_text.grid(column=0, row=11, columnspan=3)
     else:
         output_shown_flag.set(False)
         output_label.config(text="▶ Show output (advanced):")
         output_text.grid_forget()
 
 output_label = ttk.Label(frame, text="▶ Show output (advanced):")
-output_label.grid(column=0, row=9, sticky="W", columnspan=3)
+output_label.grid(column=0, row=10, sticky="W", columnspan=3)
 output_label.bind("<Button-1>", lambda e: toggle_output())
 output_text = tk.Text(frame, width=70, height=20)
 

--- a/web/index.html
+++ b/web/index.html
@@ -39,6 +39,12 @@
                         Include attachments
                         </label>
                     </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" checked id="timestamps">
+                        <label class="form-check-label" for="timestamps">
+                        Timestamp files
+                        </label>
+                    </div>
                     <div>
                         <label class="form-label me-2">Format: </label>
                         <div class="form-check form-check-inline">

--- a/web/index.js
+++ b/web/index.js
@@ -24,6 +24,7 @@ document.getElementById("convertBtn").onclick = (e) => {
     worker.postMessage({
         file: document.getElementById("olmFile").files[0],
         includeAttachments: document.getElementById("includeAttachments").checked,
+        timestamps: document.getElementById("timestamps").checked,
         format: getFormat()
     });
 };

--- a/web/olmConvertWeb.py
+++ b/web/olmConvertWeb.py
@@ -7,7 +7,7 @@ import zipfile
 import os
 
 async def init():
-    response = await pyfetch("https://raw.githubusercontent.com/PeterWarrington/olm-convert/df4cc9081a7df7184eb49b4a342b1290ef41ec04/olmConvert.py")
+    response = await pyfetch("https://raw.githubusercontent.com/beroset/olm-convert/refs/heads/add-timestamping/olmConvert.py")
     olm_convert_text = (await response.bytes()).decode("utf-8")
     with open("olmConvert.py", "w") as f:
         f.write(olm_convert_text)
@@ -21,6 +21,7 @@ async def convert():
     from js import postMessage
     from js import olmFileBytes
     from js import includeAttachments
+    from js import timestamps
     from js import format
     import olmConvert
 
@@ -71,7 +72,7 @@ async def convert():
         print(type(olmFileBytes))
 
         postMessage("startconvert")
-        olmConvert.convertOLM(olmFileBytes, output_dir, noAttachments=(not includeAttachments), verbose=True, format=format)
+        olmConvert.convertOLM(olmFileBytes, output_dir, noAttachments=(not includeAttachments), timestamps=timestamps, verbose=True, format=format)
         postMessage("progress:100%")
 
         postMessage("createzip")

--- a/web/olmConvertWorker.js
+++ b/web/olmConvertWorker.js
@@ -3,6 +3,7 @@ importScripts("https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js");
 var pyodide = null;
 var olmFile = null;
 var includeAttachments = true;
+var timestamps = false;
 var format = "eml";
 
 async function main() {
@@ -15,6 +16,7 @@ async function main() {
             f.write(await response.bytes())
     `);
     olmConvertWeb = pyodide.pyimport("olmConvertWeb");
+    await pyodide.loadPackage("python-dateutil")
     await olmConvertWeb.init();
 
     postMessage("ready");


### PR DESCRIPTION
This addresses issue #7 by optionally modifying the modified and accessed times to correspond with each message's send time.  To incorporate this into the mainline, the following additional items should be changed:

- [ ] line 10 in `olmConvertWeb.py` should point to the appropriate upstream file
- [ ] update screenshot for Windows 
- [ ] update screenshot for Linux
- [ ] update screenshot for Mac